### PR TITLE
Fix hosted docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,16 @@ rust:
   - nightly
   - stable
 sudo: false
+before_script:
+  - |
+      pip install 'travis-cargo<0.2' --user &&
+      export PATH=$HOME/.local/bin:$PATH
 env:
   global:
     - secure: YzRpe+UOEphNAMdiKdvslYnLPVhLWs10+SRvKzmdhbiq3aagIkUWewmQGdrrhYpIdHyCi/iNiOYu28aBYoh1Qr2o46JKvvZh4MtNlK0KjQOv6K4YBYL1OB3XPjTvP6Eei2Pma//G4hfChovOtCbXZT2y+vzDXgoVp8MvUS0L//g=
+    - TRAVIS_CARGO_NIGHTLY_FEATURE=
 script:
   - cargo test
   - cargo doc
-after_script:
-  - cd target
-  - curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh
+after_success:
+  - travis-cargo --only stable doc-upload


### PR DESCRIPTION
Now using [travis-cargo](https://github.com/huonw/travis-cargo) to automatically host the docs on github.io

This needs manual intervention before it can land: It needs an encrypted `GH_TOKEN` set in the Travis setting or `.travis.yml` to upload the docs to the `gh-pages` branch. Refer to the travis-cargo docs for details.