### PR TITLE
Added #[allow(deprecated)] to various locations

### DIFF
--- a/examples/brownian.rs
+++ b/examples/brownian.rs
@@ -14,6 +14,8 @@
 
 //! An example of using fractal brownian motion on perlin noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{Brownian2, Brownian3, Brownian4, perlin2, perlin3, perlin4, PermutationTable, Point2};

--- a/examples/cell_manhattan.rs
+++ b/examples/cell_manhattan.rs
@@ -14,6 +14,8 @@
 
 //! An example of using cell range noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan, PermutationTable, Point2};

--- a/examples/cell_manhattan_inv.rs
+++ b/examples/cell_manhattan_inv.rs
@@ -14,6 +14,8 @@
 
 //! An example of using cell range noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv, PermutationTable, Point2};

--- a/examples/cell_manhattan_value.rs
+++ b/examples/cell_manhattan_value.rs
@@ -14,6 +14,8 @@
 
 //! An example of using cell range noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value, PermutationTable,

--- a/examples/cell_range.rs
+++ b/examples/cell_range.rs
@@ -14,6 +14,8 @@
 
 //! An example of using cell range noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{cell2_range, cell3_range, cell4_range, PermutationTable, Point2};

--- a/examples/cell_range_inv.rs
+++ b/examples/cell_range_inv.rs
@@ -14,6 +14,8 @@
 
 //! An example of using cell range noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv, PermutationTable, Point2};

--- a/examples/cell_value.rs
+++ b/examples/cell_value.rs
@@ -14,6 +14,8 @@
 
 //! An example of using cell range noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{cell2_value, cell3_value, cell4_value, PermutationTable, Point2};

--- a/examples/complexplanet.rs
+++ b/examples/complexplanet.rs
@@ -79,11 +79,11 @@ fn main() {
     /// Planet seed. Change this to generate a different planet.
     const CURRENT_SEED: u32 = 0;
 
-    /// Minimum elevation on the planet, in meters. This value is approximate.
-    const MIN_ELEV: f64 = -8192.0;
+    // Minimum elevation on the planet, in meters. This value is approximate.
+    //const MIN_ELEV: f64 = -8192.0;
 
-    /// Maximum elevation on the planet, in meters. This value is approximate.
-    const MAX_ELEV: f64 = 8192.0;
+    // Maximum elevation on the planet, in meters. This value is approximate.
+    //const MAX_ELEV: f64 = 8192.0;
 
     /// Frequency of the planet's continents. Higher frequency produces
     /// smaller, more numerous continents. This value is measured in radians.

--- a/examples/debug/mod.rs
+++ b/examples/debug/mod.rs
@@ -14,6 +14,8 @@
 
 //! Useful things for debugging noise functions.
 
+#![allow(deprecated)]
+
 extern crate image;
 extern crate num_traits;
 

--- a/examples/value.rs
+++ b/examples/value.rs
@@ -14,6 +14,8 @@
 
 //! An example of using value noise
 
+#![allow(deprecated)]
+
 extern crate noise;
 
 use noise::{value2, value3, value4, PermutationTable, Point2};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //! ```
 
 #![deny(missing_copy_implementations)]
+#![allow(deprecated)]
 
 extern crate num_traits;
 extern crate rand;


### PR DESCRIPTION
This reduces the number of warnings by a large margin, to allow for catching useful warnings that would otherwise go missing in the steady stream of deprecation warnings. Should be removed once all currently deprecated items are completely removed.

Comments out two unused constants in the complex planet example as a result, to reduce the total number of warnings to 0 across the project and its tests.