### PR TITLE
Update benchmarks to new modules

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,466 +1,287 @@
-// Copyright 2015 The Noise-rs Developers.
+// Copyright (c) 2017 The Noise-rs Developers.
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-//! An example of using simplectic noise
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT
+// or http://opensource.org/licenses/MIT>, at your option. All files in the
+// project carrying such notice may not be copied, modified, or distributed
+// except according to those terms.
 
 #![feature(test)]
 
 extern crate noise;
 extern crate test;
 
-use noise::{cell2_manhattan, cell3_manhattan, cell4_manhattan};
-use noise::{cell2_manhattan_inv, cell3_manhattan_inv, cell4_manhattan_inv};
-use noise::{cell2_manhattan_value, cell3_manhattan_value, cell4_manhattan_value};
-use noise::{cell2_range, cell3_range, cell4_range};
-use noise::{cell2_range_inv, cell3_range_inv, cell4_range_inv};
-use noise::{cell2_value, cell3_value, cell4_value};
-use noise::{open_simplex2, open_simplex3, open_simplex4};
-use noise::{perlin2, perlin3, perlin4};
-use noise::{value2, value3, value4};
-use noise::PermutationTable;
+use noise::{NoiseModule, OpenSimplex, Perlin, SuperSimplex, Value, Worley};
 use test::{Bencher, black_box};
 
 #[bench]
-fn bench_perlin2(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| perlin2(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
-}
-
-#[bench]
-fn bench_perlin3(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| perlin3(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
-}
-
-#[bench]
-fn bench_perlin4(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| perlin4(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
-}
-
-#[bench]
 fn bench_open_simplex2(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| open_simplex2(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
+    let open_simplex = OpenSimplex::new();
+    bencher.iter(|| open_simplex.get(black_box([42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_open_simplex3(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| open_simplex3(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
+    let open_simplex = OpenSimplex::new();
+    bencher.iter(|| open_simplex.get(black_box([42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_open_simplex4(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| open_simplex4(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
+    let open_simplex = OpenSimplex::new();
+    bencher.iter(|| open_simplex.get(black_box([42.0f64, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_perlin2(bencher: &mut Bencher) {
+    let perlin = Perlin::new();
+    bencher.iter(|| perlin.get(black_box([42.0f64, 37.0])));
+}
+
+#[bench]
+fn bench_perlin3(bencher: &mut Bencher) {
+    let perlin = Perlin::new();
+    bencher.iter(|| perlin.get(black_box([42.0f64, 37.0, 26.0])));
+}
+
+#[bench]
+fn bench_perlin4(bencher: &mut Bencher) {
+    let perlin = Perlin::new();
+    bencher.iter(|| perlin.get(black_box([42.0f64, 37.0, 26.0, 128.0])));
+}
+
+#[bench]
+fn bench_super_simplex2(bencher: &mut Bencher) {
+    let super_simplex = SuperSimplex::new();
+    bencher.iter(|| super_simplex.get(black_box([42.0f64, 37.0])));
+}
+
+#[bench]
+fn bench_super_simplex3(bencher: &mut Bencher) {
+    let super_simplex = SuperSimplex::new();
+    bencher.iter(|| super_simplex.get(black_box([42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_value2(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| value2(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
+    let value = Value::new();
+    bencher.iter(|| value.get(black_box([42.0f64, 37.0])));
 }
 
 #[bench]
 fn bench_value3(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| value3(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
+    let value = Value::new();
+    bencher.iter(|| value.get(black_box([42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
 fn bench_value4(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| value4(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
+    let value = Value::new();
+    bencher.iter(|| value.get(black_box([42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
-fn bench_cell2_range(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell2_range(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
+fn bench_worley2_range(bencher: &mut Bencher) {
+    let worley = Worley::new().enable_range(true);
+    bencher.iter(|| worley.get(black_box([42.0f64, 37.0])));
 }
 
 #[bench]
-fn bench_cell3_range(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell3_range(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
+fn bench_worley3_range(bencher: &mut Bencher) {
+    let worley = Worley::new().enable_range(true);
+    bencher.iter(|| worley.get(black_box([42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
-fn bench_cell4_range(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell4_range(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
+fn bench_worley4_range(bencher: &mut Bencher) {
+    let worley = Worley::new().enable_range(true);
+    bencher.iter(|| worley.get(black_box([42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
-fn bench_cell2_range_inv(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell2_range_inv(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
+fn bench_worley2_value(bencher: &mut Bencher) {
+    let worley = Worley::new();
+    bencher.iter(|| worley.get(black_box([42.0f64, 37.0])));
 }
 
 #[bench]
-fn bench_cell3_range_inv(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell3_range_inv(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
+fn bench_worley3_value(bencher: &mut Bencher) {
+    let worley = Worley::new();
+    bencher.iter(|| worley.get(black_box([42.0f64, 37.0, 26.0])));
 }
 
 #[bench]
-fn bench_cell4_range_inv(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell4_range_inv(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
-}
-
-#[bench]
-fn bench_cell2_value(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell2_value(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
-}
-
-#[bench]
-fn bench_cell3_value(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell3_value(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
-}
-
-#[bench]
-fn bench_cell4_value(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell4_value(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
-}
-
-#[bench]
-fn bench_cell2_manhattan(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell2_manhattan(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
-}
-
-#[bench]
-fn bench_cell3_manhattan(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell3_manhattan(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
-}
-
-#[bench]
-fn bench_cell4_manhattan(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell4_manhattan(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
-}
-
-#[bench]
-fn bench_cell2_manhattan_inv(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell2_manhattan_inv(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
-}
-
-#[bench]
-fn bench_cell3_manhattan_inv(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell3_manhattan_inv(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
-}
-
-#[bench]
-fn bench_cell4_manhattan_inv(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell4_manhattan_inv(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
-}
-
-#[bench]
-fn bench_cell2_manhattan_value(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell2_manhattan_value(black_box(&perm_table), black_box(&[42.0f64, 37.0])));
-}
-
-#[bench]
-fn bench_cell3_manhattan_value(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell3_manhattan_value(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0])));
-}
-
-#[bench]
-fn bench_cell4_manhattan_value(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| cell4_manhattan_value(black_box(&perm_table), black_box(&[42.0f64, 37.0, 26.0, 128.0])));
-}
-
-#[bench]
-fn bench_perlin2_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(perlin2(black_box(&perm_table), &[x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_perlin3_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(perlin3(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_perlin4_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(perlin4(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
-        }
-    });
+fn bench_worley4_value(bencher: &mut Bencher) {
+    let worley = Worley::new();
+    bencher.iter(|| worley.get(black_box([42.0f64, 37.0, 26.0, 128.0])));
 }
 
 #[bench]
 fn bench_open_simplex2_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(open_simplex2(black_box(&perm_table), &[x as f64, y as f64]));
+    let open_simplex = OpenSimplex::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(open_simplex.get([x as f64, y as f64]));
         }
     });
 }
 
 #[bench]
 fn bench_open_simplex3_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(open_simplex3(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
+    let open_simplex = OpenSimplex::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(open_simplex.get([x as f64, y as f64, x as f64]));
         }
     });
 }
 
 #[bench]
 fn bench_open_simplex4_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(open_simplex4(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
+    let open_simplex = OpenSimplex::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(open_simplex.get([x as f64, y as f64, x as f64, y as f64]));
+        }
+    });
+}
+
+#[bench]
+fn bench_perlin2_64x64(bencher: &mut Bencher) {
+    let perlin = Perlin::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(perlin.get([x as f64, y as f64]));
+        }
+    });
+}
+
+#[bench]
+fn bench_perlin3_64x64(bencher: &mut Bencher) {
+    let perlin = Perlin::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(perlin.get([x as f64, y as f64, x as f64]));
+        }
+    });
+}
+
+#[bench]
+fn bench_perlin4_64x64(bencher: &mut Bencher) {
+    let perlin = Perlin::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(perlin.get([x as f64, y as f64, x as f64, y as f64]));
+        }
+    });
+}
+
+#[bench]
+fn bench_super_simplex2_64x64(bencher: &mut Bencher) {
+    let super_simplex = SuperSimplex::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(super_simplex.get([x as f64, y as f64]));
+        }
+    });
+}
+
+#[bench]
+fn bench_super_simplex3_64x64(bencher: &mut Bencher) {
+    let super_simplex = SuperSimplex::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(super_simplex.get([x as f64, y as f64, x as f64]));
         }
     });
 }
 
 #[bench]
 fn bench_value2_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(value2(black_box(&perm_table), &[x as f64, y as f64]));
+    let value = Value::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(value.get([x as f64, y as f64]));
         }
     });
 }
 
 #[bench]
 fn bench_value3_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(value3(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
+    let value = Value::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(value.get([x as f64, y as f64, x as f64]));
         }
     });
 }
 
 #[bench]
 fn bench_value4_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(value4(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
+    let value = Value::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(value.get([x as f64, y as f64, x as f64, y as f64]));
         }
     });
 }
 
 #[bench]
-fn bench_cell2_range_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell2_range(black_box(&perm_table), &[x as f64, y as f64]));
+fn bench_worley2_range_64x64(bencher: &mut Bencher) {
+    let worley = Worley::new().enable_range(true);
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(worley.get([x as f64, y as f64]));
         }
     });
 }
 
 #[bench]
-fn bench_cell3_range_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell3_range(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
+fn bench_worley3_range_64x64(bencher: &mut Bencher) {
+    let worley = Worley::new().enable_range(true);
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(worley.get([x as f64, y as f64, x as f64]));
         }
     });
 }
 
 #[bench]
-fn bench_cell4_range_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell4_range(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
+fn bench_worley4_range_64x64(bencher: &mut Bencher) {
+    let worley = Worley::new().enable_range(true);
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(worley.get([x as f64, y as f64, x as f64, y as f64]));
         }
     });
 }
 
 #[bench]
-fn bench_cell2_range_inv_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell2_range_inv(black_box(&perm_table), &[x as f64, y as f64]));
+fn bench_worley2_value_64x64(bencher: &mut Bencher) {
+    let worley = Worley::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(worley.get([x as f64, y as f64]));
         }
     });
 }
 
 #[bench]
-fn bench_cell3_range_inv_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell3_range_inv(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
+fn bench_worley3_value_64x64(bencher: &mut Bencher) {
+    let worley = Worley::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(worley.get([x as f64, y as f64, x as f64]));
         }
     });
 }
 
 #[bench]
-fn bench_cell4_range_inv_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell4_range_inv(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell2_value_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell2_value(black_box(&perm_table), &[x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell3_value_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell3_value(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell4_value_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell4_value(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell2_manhattan_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell2_manhattan(black_box(&perm_table), &[x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell3_manhattan_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell3_manhattan(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell4_manhattan_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell4_manhattan(black_box(&perm_table), &[x as f64, y as f64, x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell2_manhattan_inv_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell2_manhattan_inv(black_box(&perm_table), &[x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell3_manhattan_inv_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell3_manhattan_inv(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell4_manhattan_inv_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell4_manhattan_inv(black_box(&perm_table),
-                                          &[x as f64, y as f64, x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell2_manhattan_value_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell2_manhattan_value(black_box(&perm_table), &[x as f64, y as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell3_manhattan_value_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell3_manhattan_value(black_box(&perm_table), &[x as f64, y as f64, x as f64]));
-        }
-    });
-}
-
-#[bench]
-fn bench_cell4_manhattan_value_64x64(bencher: &mut Bencher) {
-    let perm_table = PermutationTable::new(0);
-    bencher.iter(|| for y in 0..64 {
-        for x in 0..64 {
-            black_box(cell4_manhattan_value(black_box(&perm_table),
-                                            &[x as f64, y as f64, x as f64, y as f64]));
+fn bench_worley4_value_64x64(bencher: &mut Bencher) {
+    let worley = Worley::new();
+    bencher.iter(|| for y in 0i8..64 {
+        for x in 0i8..64 {
+            black_box(worley.get([x as f64, y as f64, x as f64, y as f64]));
         }
     });
 }


### PR DESCRIPTION
This ports the benchmarks to the new modules, removes the no longer relevant Worley benchmarks, and adds SuperSimplex benchmarks.