### PR TITLE
Avoid using `mul_add()` when target OS is Emscripten

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -316,13 +316,13 @@ pub fn to_isize2(x: Point2<f64>) -> Point2<isize> {
 #[cfg(not(target_os = "emscripten"))]
 #[inline]
 pub fn scale_shift(value: f64, n: f64) -> f64 {
-    value.abs().mul_add(cast(n), -1.0_f64)
+    value.abs().mul_add(n, -1.0_f64)
 }
 
 #[cfg(target_os = "emscripten")]
 #[inline]
 pub fn scale_shift(value: f64, n: f64) -> f64 {
-    (value.abs() * cast(n)) + -1.0_f64
+    (value.abs() * n) + -1.0_f64
 }
 
 #[inline]
@@ -351,7 +351,7 @@ pub mod interp {
     /// Performs linear interploation between two values.
     #[cfg(target_os = "emscripten")]
     #[inline]
-    pub fn linear<T: Float>(a: T, b: T, x: T) -> T {
+    pub fn linear(a: f64, b: f64, x: f64) -> f64 {
         (x * (b - a)) + a
     }
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -313,6 +313,18 @@ pub fn to_isize2(x: Point2<f64>) -> Point2<isize> {
     [x[0] as isize, x[1] as isize]
 }
 
+#[cfg(not(target_os = "emscripten"))]
+#[inline]
+pub fn scale_shift(value: f64, n: f64) -> f64 {
+    value.abs().mul_add(cast(n), -1.0_f64)
+}
+
+#[cfg(target_os = "emscripten")]
+#[inline]
+pub fn scale_shift(value: f64, n: f64) -> f64 {
+    (value.abs() * cast(n)) + -1.0_f64
+}
+
 #[inline]
 pub fn to_isize3(x: Point3<f64>) -> Point3<isize> {
     [x[0] as isize, x[1] as isize, x[2] as isize]
@@ -330,9 +342,17 @@ pub fn to_isize4(x: Point4<f64>) -> Point4<isize> {
 
 pub mod interp {
     /// Performs linear interploation between two values.
+    #[cfg(not(target_os = "emscripten"))]
     #[inline]
     pub fn linear(a: f64, b: f64, x: f64) -> f64 {
         x.mul_add((b - a), a)
+    }
+
+    /// Performs linear interploation between two values.
+    #[cfg(target_os = "emscripten")]
+    #[inline]
+    pub fn linear<T: Float>(a: T, b: T, x: T) -> T {
+        (x * (b - a)) + a
     }
 
     /// Performs cubic interpolation between two values bound between two other

--- a/src/noise_fns/generators/fractals/billow.rs
+++ b/src/noise_fns/generators/fractals/billow.rs
@@ -6,8 +6,7 @@
 // project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
 
-use math;
-use math::{Point2, Point3, Point4};
+use math::{self, scale_shift, Point2, Point3, Point4};
 use noise_fns::{MultiFractal, NoiseFn, Perlin, Seedable};
 
 /// Default noise seed for the Billow noise function.
@@ -150,7 +149,7 @@ impl NoiseFn<Point2<f64>> for Billow {
 
             // Take the abs of the signal, then scale and shift back to
             // the [-1,1] range.
-            signal = signal.abs().mul_add(2.0, -1.0);
+            signal = scale_shift(signal, 2.0);
 
             // Scale the amplitude appropriately for this frequency.
             signal *= self.persistence.powi(x as i32);
@@ -180,7 +179,7 @@ impl NoiseFn<Point3<f64>> for Billow {
 
             // Take the abs of the signal, then scale and shift back to
             // the [-1,1] range.
-            signal = signal.abs().mul_add(2.0, -1.0);
+            signal = scale_shift(signal, 2.0);
 
             // Scale the amplitude appropriately for this frequency.
             signal *= self.persistence.powi(x as i32);
@@ -210,7 +209,7 @@ impl NoiseFn<Point4<f64>> for Billow {
 
             // Take the abs of the signal, then scale and shift back to
             // the [-1,1] range.
-            signal = signal.abs().mul_add(2.0, -1.0);
+            signal = scale_shift(signal, 2.0);
 
             // Scale the amplitude appropriately for this frequency.
             signal *= self.persistence.powi(x as i32);

--- a/src/noise_fns/generators/fractals/ridgedmulti.rs
+++ b/src/noise_fns/generators/fractals/ridgedmulti.rs
@@ -6,8 +6,7 @@
 // project carrying such notice may not be copied, modified, or distributed
 // except according to those terms.
 
-use math;
-use math::{Point2, Point3, Point4};
+use math::{self, scale_shift, Point2, Point3, Point4};
 use noise_fns::{MultiFractal, NoiseFn, Perlin, Seedable};
 
 /// Default noise seed for the `RidgedMulti` noise function.
@@ -204,7 +203,7 @@ impl NoiseFn<Point2<f64>> for RidgedMulti {
 
         // Scale and shift the result into the [-1,1] range
         let scale = 2.0 - 0.5_f64.powi(self.octaves as i32 - 1);
-        result.mul_add(2.0 / scale, -1.0)
+        scale_shift(result, 2.0 / scale)
     }
 }
 
@@ -250,7 +249,7 @@ impl NoiseFn<Point3<f64>> for RidgedMulti {
 
         // Scale and shift the result into the [-1,1] range
         let scale = 2.0 - 0.5_f64.powi(self.octaves as i32 - 1);
-        result.mul_add(2.0 / scale, -1.0)
+        scale_shift(result, 2.0 / scale)
     }
 }
 
@@ -296,6 +295,6 @@ impl NoiseFn<Point4<f64>> for RidgedMulti {
 
         // Scale and shift the result into the [-1,1] range
         let scale = 2.0 - 0.5_f64.powi(self.octaves as i32 - 1);
-        result.mul_add(2.0 / scale, -1.0)
+        scale_shift(result, 2.0 / scale)
     }
 }

--- a/src/noise_fns/modifiers/exponent.rs
+++ b/src/noise_fns/modifiers/exponent.rs
@@ -8,6 +8,8 @@
 
 use noise_fns::NoiseFn;
 
+use math::scale_shift;
+
 /// Noise function that maps the output value from the source function onto an
 /// exponential curve.
 ///
@@ -46,6 +48,6 @@ impl<'a, T> NoiseFn<T> for Exponent<'a, T> {
         value = (value + 1.0) / 2.0;
         value = value.abs();
         value = value.powf(self.exponent);
-        value.mul_add(2.0, -1.0)
+        scale_shift(value, 2.0)
     }
 }

--- a/src/noise_fns/modifiers/scale_bias.rs
+++ b/src/noise_fns/modifiers/scale_bias.rs
@@ -48,7 +48,13 @@ impl<'a, T> ScaleBias<'a, T> {
 }
 
 impl<'a, T> NoiseFn<T> for ScaleBias<'a, T> {
+    #[cfg(not(target_os = "emscripten"))]
     fn get(&self, point: T) -> f64 {
         (self.source.get(point)).mul_add(self.scale, self.bias)
+    }
+
+    #[cfg(target_os = "emscripten")]
+    fn get(&self, point: T) -> f64 {
+        (self.source.get(point) * self.scale) + self.bias
     }
 }


### PR DESCRIPTION
Due to the inability to access CPU-level instructions in Asm.JS and WebAssembly, the Emscripten toolchain has no implementation of the `llvm_fma_f32` and `llvm_fma_f64` intrinsics.  This is a known problem
and has discussion on this Github issue: https://github.com/kripken/emscripten-fastcomp/issues/83

Rust's `mul_add()` implementation directly invokes this intrinsic (https://doc.rust-lang.org/src/std/f32.rs.html#425) which causes compilation to fail.

This commit adds conditionally compiled alternatives to all uses of the `mul_add()` function in the library, falling back to discrete multiply and add operations.  This allows the library to fully
compile using Emscripten.

----

If could be argued that this is a Rust/Emscripten/LLVM issue and that this library wouldn't benefit from these changes.  If that's the case, don't worry about rejecting this PR; I'm happy to maintain a fork for my project.